### PR TITLE
add a simple test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.2"
+# install test suite dependencies and module itself
+install:
+  - "pip install -r tests/requirements.txt"
+  - "python setup.py install"
+# run tests
+script: python setup.py test

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,23 @@ switch_off(1)
 switch_off(4)
 ```
 
+## Testing
+
+A basic test suite is included which can be used to test the module even when
+not running on the Pi. The test suite may be run via ``setup.py``.
+
+### Python 3:
+
+```bash
+python-3.2 setup.py test
+```
+
+### Python 2:
+
+```bash
+python setup.py test
+```
+
 ## Contributors
 
 - [Ben Nuttall](https://github.com/bennuttall) (project maintainer)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[nosetests]
+exclude=energenie

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,10 @@ setup(
     install_requires=[
         "RPi.GPIO",
     ],
+    tests_require=[
+        "mock",
+        "nose",
+    ],
     long_description=read('README.rst'),
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "mock",
         "nose",
     ],
+    test_suite = "nose.collector",
     long_description=read('README.rst'),
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+nose
+mock

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -1,0 +1,129 @@
+from mock import patch, MagicMock, call
+from nose.tools import assert_greater_equal, assert_equal
+
+# Energenie I/O pins in bit 4, 3, 2 and 1 order
+_IO_PINS = [27, 23, 22, 17]
+
+# Energenie control pins
+_ON_OFF = 24
+_ENABLE = 25
+
+# We need to explicitly create a mock for RPio.GPIO since we want to have the
+# mock used at import time. Create a mocked RPi.GPIO module which we can use to
+# test energenie without a) having to have the hardware installed and/or b)
+# having to run on the pi.
+_RPi_mock = MagicMock()
+_RPi_mock.GPIO = MagicMock()
+
+# This is the dict which should be patched into sys.modules to make imports
+# work.
+_mocked_modules = {
+    'RPi': _RPi_mock,
+    'RPi.GPIO': _RPi_mock.GPIO,
+}
+
+_GPIO_PATCHER = patch.dict('sys.modules', _mocked_modules)
+
+@_GPIO_PATCHER
+def test_energenie_initial_setup():
+    """Tests that energenie initialises the module correctly at import time."""
+    import energenie
+    GPIO = _RPi_mock.GPIO
+
+    GPIO.setmode.assert_called_once_with(GPIO.BCM)
+    GPIO.setwarnings.assert_called_once_with(False)
+
+    # Check pins are set up for output
+    for pin in _IO_PINS + [_ON_OFF, _ENABLE]:
+        GPIO.setup.assert_any_call(pin, GPIO.OUT)
+
+    # Check all pins are low
+    for pin in _IO_PINS + [_ON_OFF, _ENABLE]:
+        GPIO.output.assert_any_call(pin, False)
+
+def _assert_enabled_toggled():
+    # The enable pin should've been toggled high and *then* low
+    _RPi_mock.GPIO.output.assert_has_calls([
+        call(_ENABLE, True),
+        call(_ENABLE, False),
+    ])
+
+def _assert_one_on(socket_num):
+    # Assert that a single socket was switched on
+    code = [0b1111, 0b1110, 0b1101, 0b1100][socket_num - 1]
+    for bit in range(4):
+        value = True if code & (1<<bit) != 0 else False
+        _RPi_mock.GPIO.output.assert_any_call(_IO_PINS[3-bit], value)
+
+def _assert_one_off(socket_num):
+    # Assert that a single socket was switched off
+    code = [0b0111, 0b0110, 0b0101, 0b0100][socket_num - 1]
+    for bit in range(4):
+        value = True if code & (1<<bit) != 0 else False
+        _RPi_mock.GPIO.output.assert_any_call(_IO_PINS[3-bit], value)
+
+@_GPIO_PATCHER
+def test_switch_all_on():
+    from energenie import switch_on
+
+    GPIO = _RPi_mock.GPIO
+    GPIO.output.reset_mock()
+    assert_equal(GPIO.output.call_count, 0)
+
+    switch_on()
+
+    # We should've set at least six pins
+    assert_greater_equal(GPIO.output.call_count, 6)
+
+    GPIO.output.assert_any_call(_IO_PINS[0], True)
+    GPIO.output.assert_any_call(_IO_PINS[1], False)
+    GPIO.output.assert_any_call(_IO_PINS[2], True)
+    GPIO.output.assert_any_call(_IO_PINS[3], True)
+
+    _assert_enabled_toggled()
+
+@_GPIO_PATCHER
+def test_switch_all_off():
+    from energenie import switch_off
+
+    GPIO = _RPi_mock.GPIO
+    GPIO.output.reset_mock()
+    assert_equal(GPIO.output.call_count, 0)
+
+    switch_off()
+
+    # We should've set at least six pins
+    assert_greater_equal(GPIO.output.call_count, 6)
+
+    GPIO.output.assert_any_call(_IO_PINS[0], False)
+    GPIO.output.assert_any_call(_IO_PINS[1], False)
+    GPIO.output.assert_any_call(_IO_PINS[2], True)
+    GPIO.output.assert_any_call(_IO_PINS[3], True)
+
+    _assert_enabled_toggled()
+
+@_GPIO_PATCHER
+def test_switch_on_individual():
+    from energenie import switch_on
+
+    # Test switching on each socket in turn
+    for socket in range(1,5):
+        print("Testing socket {0}".format(socket))
+        _RPi_mock.GPIO.output.reset_mock()
+        switch_on(socket)
+        print(_RPi_mock.GPIO.output.mock_calls)
+        _assert_one_on(socket)
+        _assert_enabled_toggled()
+
+@_GPIO_PATCHER
+def test_switch_off_individual():
+    from energenie import switch_off
+
+    # Test switching off each socket in turn
+    for socket in range(1,5):
+        print("Testing socket {0}".format(socket))
+        _RPi_mock.GPIO.output.reset_mock()
+        switch_off(socket)
+        print(_RPi_mock.GPIO.output.mock_calls)
+        _assert_one_off(socket)
+        _assert_enabled_toggled()


### PR DESCRIPTION
This PR adds a very simple test suite which checks that the appropriate GPIO
pins are twiddled when the API is used and includes a configuration for
Travis-CI which can be used to check the module works with Python 2.7 and 3.2
(see [1]).

The test suite makes use of unittest.mock (or, more precisely, the 2.7
backport) to mock RPi.GPIO allowing a) the test suite to be run on something
other then the Pi (e.g. Travis) and b) to not require hardware monitoring of
the GPIO to verify logic.

Should one want to extend the API at a later time to allow, e.g., multiple
sockets per call to switch_{on,off}(), this test suite can at least verify that
the API hasn't broken.

No ego will be harmed if the PR isn't merged. It's possibly overkill to have a
test suite for a two-function package but it *is* good practice.

[1] https://travis-ci.org/rjw57/energenie/builds/46191173
[2] https://docs.python.org/3/library/unittest.mock.html